### PR TITLE
Add Date: header to all meeting notes

### DIFF
--- a/documents/meetings/meeting-2024-01-15.md
+++ b/documents/meetings/meeting-2024-01-15.md
@@ -1,3 +1,4 @@
+Date: 2024-01-15
 # Meeting Notes: Q1 Planning
 
 **Date:** 2024-01-15

--- a/documents/meetings/meeting-2024-02-05.md
+++ b/documents/meetings/meeting-2024-02-05.md
@@ -1,3 +1,4 @@
+Date: 2024-02-05
 # Meeting Notes: Sprint Review & Retrospective
 
 **Date:** 2024-02-05

--- a/documents/meetings/meeting-2024-03-10.md
+++ b/documents/meetings/meeting-2024-03-10.md
@@ -1,3 +1,4 @@
+Date: 2024-03-10
 # Meeting Notes: Team Sync
 
 **Date:** 2024-03-10


### PR DESCRIPTION
Prepend a `Date: YYYY-MM-DD` header line to each meeting note in `documents/meetings/` that did not already have one. Dates are derived from each file's name.

Closes #7

Generated with [Claude Code](https://claude.ai/code)